### PR TITLE
Update Quickstart link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,5 @@ GROUP BY carrier
 ORDER BY flight_count desc         -- malloy automatically orders by the first aggregate
 ```
 
-Learn more about the syntax and language features of Malloy in the [Quickstart](https://malloydata.github.io/documentation/language/basic.html).
+Learn more about the syntax and language features of Malloy in the
+[Quickstart](https://malloydata.github.io/documentation/user_guides/basic.html).


### PR DESCRIPTION
Update Quickstart link to
https://malloydata.github.io/documentation/user_guides/basic.html from a 404 of 
https://malloydata.github.io/documentation/language/basic.html